### PR TITLE
fix: Reset Application Center Settings on server Startup - MEED-768

### DIFF
--- a/meeds-qa-ui-data-services/src/main/resources/conf/configuration.xml
+++ b/meeds-qa-ui-data-services/src/main/resources/conf/configuration.xml
@@ -23,13 +23,21 @@ Inc., 51 Franklin Street, Fifth Floor, Boston, MA  02110-1301, USA.
    xmlns="http://www.exoplatform.org/xml/ns/kernel_1_2.xsd">
 
   <component>
-    <key>SpaceAdministratorsProperties</key>
+    <key>QA UI Data Properties</key>
     <type>org.exoplatform.container.ExtendedPropertyConfigurator</type>
     <init-params>
       <properties-param>
-        <name>SpaceAdministratorsProperties</name>
+        <name>QA UI Data Properties</name>
         <description>Extend Space Administrators to portal administrators</description>
         <property name="social.spaces.administrators" value="*:/platform/administrators" />
+        <property name="exo.app-center.tasks.override" value="true" />
+        <property name="exo.app-center.tasks.override-mode" value="overwrite" />
+        <property name="exo.app-center.perkstore.override" value="true" />
+        <property name="exo.app-center.perkstore.override-mode" value="overwrite" />
+        <property name="exo.app-center.challenges.override" value="true" />
+        <property name="exo.app-center.challenges.override-mode" value="overwrite" />
+        <property name="exo.app-center.wallet.override" value="true" />
+        <property name="exo.app-center.wallet.override-mode" value="overwrite" />
       </properties-param>
     </init-params>
   </component>


### PR DESCRIPTION
Prior to this change, the App Center Settings wasn't reset to its original value from configuration which can lead to Tests failure when data changes on database using App Center Administration UI (such as making Tasks Application non mandatory). This change will ensure to overwrite the changed App Center settings by UI each server startup to preserve tests conditions through Tests executions, so that it fails only when the default parameters in product changes.